### PR TITLE
Extensibility: Switch to using interfaces

### DIFF
--- a/MailSim/MailSim/Contracts/IAddressBook.cs
+++ b/MailSim/MailSim/Contracts/IAddressBook.cs
@@ -1,0 +1,24 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace MailSim.Contracts
+{
+    interface IAddressBook
+    {
+        /// <summary>
+        /// Builds list of addresses for all users in the Address List that have display name match
+        /// </summary>
+        /// <param name="match"> string to match in user name or null to return all users in the GAL</param>
+        /// <returns>List of SMTP addresses of matching users in the address list. The list will be empty if no users exist or match.</returns>
+        IEnumerable<string> GetUsers(string match);
+        /// <summary>
+        /// Builds list of addresses for all members of Exchange Distribution list in the Address List
+        /// </summary>
+        /// <param name="dLName">Exchane Distribution List Name</param>
+        /// <returns>List of SMTP addresses of DL members or null if DL is not found. Nesting DLs are not expanded. </returns>
+        IEnumerable<string> GetDLMembers(string dLName);
+    }
+}

--- a/MailSim/MailSim/Contracts/IMailFolder.cs
+++ b/MailSim/MailSim/Contracts/IMailFolder.cs
@@ -1,0 +1,63 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace MailSim.Contracts
+{
+    interface IMailFolder
+    {
+        /// <summary>
+        /// Display Name of current folder
+        /// </summary>
+        string Name { get; }
+        /// <summary>
+        /// Folder Path of this folder
+        /// </summary>
+        string FolderPath { get; }
+        /// <summary>
+        /// Collection of MailItems in current folder
+        /// </summary>
+        /// <returns>IEnumerable of IMailItem</returns>
+        IEnumerable<IMailItem> MailItems { get; }
+        /// <summary>
+        /// Collection of subfolders within this folder
+        /// </summary>
+        /// <returns>IEnumerable of IMailFolder</returns>
+        IEnumerable<IMailFolder> SubFolders { get; }
+        /// <summary>
+        /// Registers event handler for ItemAdd event for new mail in the folder (i.e. new MailSim.OL.MailItem).
+        /// </summary>
+        /// <param name="callback">public static void FolderEvent(MailItem mail)</param>
+        void RegisterItemAddEventHandler(Action<IMailItem> callback);
+        /// <summary>
+        /// Unregisters event handler previously registered with RegisterItemAddEventHandler
+        /// </summary>
+        void UnRegisterItemAddEventHandler();
+        /// <summary>
+        /// Number of mail items in the current folder
+        /// </summary>
+        int MailItemsCount { get; }
+        /// <summary>
+        /// Number of subfolders in the current folder
+        /// </summary>
+        int SubFoldersCount { get; }
+        /// <summary>
+        /// Adds folder as a subfolder of current folder
+        /// </summary>
+        /// <param name="name">Nam of new folder</param>
+        /// <returns></returns>
+        IMailFolder AddSubFolder(string name);
+        /// <summary>
+        /// Deletes current folder
+        /// </summary>
+        void Delete();
+#if false
+        /// <summary>
+        /// Default Message Class of current folder
+        /// </summary>
+        public string DefaultMessageClass { get; }
+#endif
+    }
+}

--- a/MailSim/MailSim/Contracts/IMailItem.cs
+++ b/MailSim/MailSim/Contracts/IMailItem.cs
@@ -1,0 +1,73 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace MailSim.Contracts
+{
+    interface IMailItem
+    {
+        /// <summary>
+        /// Mail subject field
+        /// </summary>
+        string Subject { get; set; }
+        /// <summary>
+        /// Mail body
+        /// </summary>
+        string Body { get; set; }
+        /// <summary>
+        /// Mail sender name
+        /// </summary>
+        string SenderName { get; }
+        /// <summary>
+        /// Adds recipient to recipient's list of the message
+        /// </summary>
+        /// <param name="recipient">recipient</param>
+        void AddRecipient(string recipient);
+        /// <summary>
+        /// Adds file attachment to the current message
+        /// </summary>
+        /// <param name="file">Full file path to the file to attach</param>
+        void AddAttachment(string fileName);
+        /// <summary>
+        /// Adds message as attachment to current message
+        /// </summary>
+        /// <param name="mailitem"></param>
+        void AddAttachment(IMailItem mailItem);
+        /// <summary>
+        /// Send this message
+        /// </summary>
+        void Send();
+        /// <summary>
+        /// Deletes this message
+        /// </summary>
+        void Delete();
+        /// <summary>
+        /// Moves Mail item into new folder
+        /// </summary>
+        /// <param name="destination" - IMailFolder representing folder to move to></param>
+        void Move(IMailFolder destination);
+        /// <summary>
+        /// Resolves and validates all recipients. Returns true if successful; false if one or more recipients cannot be resolved.  
+        /// </summary>
+        bool ValidateRecipients();
+        /// <summary>
+        /// Creates a reply, pre-addressed to the original sender or all original recipients, from the original message
+        /// </summary>
+        /// <param name="replyAll" - replies to all original recipients if true; only to the original sender if false></param>
+        /// <returns>IMailItem object that represents the reply</returns>
+        IMailItem Reply(bool replyAll);
+        /// <summary>
+        /// Executes the Forward action for an item and returns the resulting copy as a MailItem object
+        /// </summary>
+        /// <returns>IMailItem object that represents the new mail item</returns>
+        IMailItem Forward();
+#if false
+        /// <summary>
+        /// HTML Body of the email
+        /// </summary>
+        public string HTMLBody { get; set; }
+#endif
+    }
+}

--- a/MailSim/MailSim/Contracts/IMailStore.cs
+++ b/MailSim/MailSim/Contracts/IMailStore.cs
@@ -1,0 +1,42 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace MailSim.Contracts
+{
+    interface IMailStore
+    {
+        /// <summary>
+        /// Creates new MailItem associated with this MailStore. 
+        /// Typically used for new mail, to be sent from user account of this MailStore.  
+        /// </summary>
+        /// <returns>IMailItem</returns>
+        IMailItem NewMailItem();
+        /// <summary>
+        /// Display name of the store (mailbox) represented by this object
+        /// </summary>
+        string DisplayName { get; }
+        /// <summary>
+        /// Top level (root) folder of the mailbox store
+        /// </summary>
+        /// <returns>IMailFolder object that includes all Folders on top level folder layer</returns>
+        IMailFolder RootFolder { get; }
+        /// <summary>
+        /// Returns one of "Default" folders in the mailbox
+        /// For list of possible folders refer to
+        /// https://msdn.microsoft.com/en-us/library/office/microsoft.office.interop.outlook.oldefaultfolders(v=vs.15).aspx
+        /// This class supports the following: 
+        /// "olFolderInbox", "olFolderDeletedItems", "olFolderDrafts", "olFolderJunk", "olFolderOutbox", "olFolderSentMail"
+        /// </summary>
+        /// <param name="folderName">String representing one of default folders (ex.: "olFolderInbox"). </param>
+        /// <returns>MailFolder object or null if string does not match supported value</returns>
+        IMailFolder GetDefaultFolder(string name);
+        /// <summary>
+        /// Finds the Global Address List associated with the MailStore
+        /// </summary>
+        /// <returns>IAddressBook for GAL or null if store has no GAL</returns>
+        IAddressBook GetGlobalAddressList();
+    }
+}

--- a/MailSim/MailSim/ExecuteSequence.cs
+++ b/MailSim/MailSim/ExecuteSequence.cs
@@ -14,7 +14,7 @@ using System.Xml;
 using Microsoft.Win32;
 using System.Linq;
 
-using MailSim.OL;
+using MailSim.Contracts;
 
 namespace MailSim
 {
@@ -23,8 +23,7 @@ namespace MailSim
         private MailSimSequence sequence;
         private MailSimOperations operations;
         private XmlDocument operationXML;
-        private MailConnection olConnection;
-        private MailStore olMailStore;
+        private IMailStore olMailStore;
         private Random randomNum;
 
         private const string OfficeVersion = "15.0";
@@ -38,7 +37,7 @@ namespace MailSim
         private const int MaxNumberOfRandomFolder = 100;
         private const string StopFileName = "stop.txt";
 
-        private List<MailFolder> FolderEventList = new List<MailFolder>();
+        private List<IMailFolder> FolderEventList = new List<IMailFolder>();
         private IDictionary<Type, Func<object, bool>> typeFuncs = new Dictionary<Type, Func<object, bool>>();
 
         private string DefaultInboxMonitor = "DefaultInboxMonitor";
@@ -73,10 +72,8 @@ namespace MailSim
                     }
 
                     // Openes connection to Outlook with default profile, starts Outlook if it is not running
-                    olConnection = new MailConnection();
-
                     // Note: Currently only the default MailStore is supported.
-                    olMailStore = olConnection.GetDefaultStore();
+                    olMailStore = ProviderFactory.CreateMailStore(null);
 
                     // Initializes a random number
                     randomNum = new Random();
@@ -111,7 +108,7 @@ namespace MailSim
         public void CleanupAfterIteration()
         {
             // Unregisters all registered folder events 
-            foreach (MailFolder folder in FolderEventList)
+            foreach (IMailFolder folder in FolderEventList)
             {
                 RegisterFolderEvent(DefaultInboxMonitor, folder, false);
             }
@@ -264,7 +261,7 @@ namespace MailSim
                 try
                 {
                     // generates a new email
-                    MailItem mail = olMailStore.NewMailItem();
+                    IMailItem mail = olMailStore.NewMailItem();
 
                     mail.Subject = mail.Body = System.DateTime.Now.ToString() + " - ";
                     mail.Subject += (string.IsNullOrEmpty(operation.Subject)) ? DefaultSubject : operation.Subject;
@@ -314,8 +311,8 @@ namespace MailSim
             try
             {
                 // Retrieves mails from Outlook
-                List<MailItem> mails = GetMails(operation.OperationName, operation.Folder, operation.Subject);
-                if (mails == null || mails.Count == 0)
+                var mails = GetMails(operation.OperationName, operation.Folder, operation.Subject).ToList();
+                if (mails.Any() == false)
                 {
                     Log.Out(Log.Severity.Error, operation.OperationName, "Skipping MailDelete");
                     return false;
@@ -378,8 +375,8 @@ namespace MailSim
             try
             {
                 // retrieves mails from Outlook
-                List<MailItem> mails = GetMails(operation.OperationName, operation.Folder, operation.MailSubjectToReply);
-                if (mails == null || mails.Count == 0)
+                var mails = GetMails(operation.OperationName, operation.Folder, operation.MailSubjectToReply).ToList();
+                if (mails.Any() == false)
                 {
                     Log.Out(Log.Severity.Error, operation.OperationName, "Skipping MailReply");
                     return false;
@@ -411,7 +408,7 @@ namespace MailSim
                     // just reply the email in order if random is not selected,
                     // otherwise randomly pick the mail to reply
                     int indexToReply = random ? randomNum.Next(0, mails.Count) : count - 1;
-                    MailItem mailToReply = mails[indexToReply].Reply(operation.ReplyAll);
+                    IMailItem mailToReply = mails[indexToReply].Reply(operation.ReplyAll);
 
                     Log.Out(Log.Severity.Info, operation.OperationName, "Subject: {0}", mailToReply.Subject);
 
@@ -457,8 +454,8 @@ namespace MailSim
             try
             {
                 // retrieves mails from Outlook
-                List<MailItem> mails = GetMails(operation.OperationName, operation.Folder, operation.MailSubjectToForward);
-                if (mails == null || mails.Count == 0)
+                var mails = GetMails(operation.OperationName, operation.Folder, operation.MailSubjectToForward).ToList();
+                if (mails.Any() == false)
                 {
                     Log.Out(Log.Severity.Error, operation.OperationName, "Skipping MailForward");
                     return false;
@@ -498,7 +495,7 @@ namespace MailSim
                     // just forward the email in order if random is not selected,
                     // otherwise randomly pick the mail to forward
                     int indexToForward = random ? randomNum.Next(0, mails.Count) : count - 1;
-                    MailItem mailToForward = mails[indexToForward].Forward();
+                    IMailItem mailToForward = mails[indexToForward].Forward();
 
                     Log.Out(Log.Severity.Info, operation.OperationName, "Subject: {0}", mailToForward.Subject);
 
@@ -551,8 +548,8 @@ namespace MailSim
             try
             {
                 // retrieves mails from Outlook
-                List<MailItem> mails = GetMails(operation.OperationName, operation.SourceFolder, operation.Subject);
-                if (mails == null || mails.Count == 0)
+                var mails = GetMails(operation.OperationName, operation.SourceFolder, operation.Subject).ToList();
+                if (mails.Any() == false)
                 {
                     Log.Out(Log.Severity.Error, operation.OperationName, "Skipping MailMove");
                     return false;
@@ -576,7 +573,7 @@ namespace MailSim
                 }
 
                 // gets the Outlook destination folder
-                MailFolder destinationFolder = olMailStore.GetDefaultFolder(operation.DestinationFolder);
+                IMailFolder destinationFolder = olMailStore.GetDefaultFolder(operation.DestinationFolder);
                 if (destinationFolder == null)
                 {
                     Log.Out(Log.Severity.Error, operation.OperationName, "Unable to retrieve folder {0}",
@@ -623,7 +620,7 @@ namespace MailSim
             try
             {
                 // gets the Outlook folder
-                MailFolder folder = olMailStore.GetDefaultFolder(operation.FolderPath);
+                IMailFolder folder = olMailStore.GetDefaultFolder(operation.FolderPath);
                 if (folder == null)
                 {
                     Log.Out(Log.Severity.Error, operation.OperationName, "Unable to retrieve folder {0}",
@@ -673,7 +670,7 @@ namespace MailSim
             try
             {
                 // gets the Outlook folder
-                MailFolder folder = olMailStore.GetDefaultFolder(operation.FolderPath);
+                IMailFolder folder = olMailStore.GetDefaultFolder(operation.FolderPath);
                 if (folder == null)
                 {
                     Log.Out(Log.Severity.Error, operation.OperationName, "Unable to retrieve folder {0}",
@@ -681,7 +678,7 @@ namespace MailSim
                     return false;
                 }
 
-                List<MailFolder> subFolders = GetMatchingSubFolders(operation.OperationName, folder, operation.FolderName);
+                var subFolders = GetMatchingSubFolders(operation.OperationName, folder, operation.FolderName).ToList();
                 if (subFolders.Count == 0)
                 {
                     Log.Out(Log.Severity.Error, operation.OperationName, "There is no matching folder to delete in folder {0}",
@@ -739,7 +736,7 @@ namespace MailSim
             try
             {
                 // gets the default Outlook folder
-                MailFolder folder = olMailStore.GetDefaultFolder(operation.Folder);
+                IMailFolder folder = olMailStore.GetDefaultFolder(operation.Folder);
                 if (folder == null)
                 {
                     Log.Out(Log.Severity.Error, operation.OperationName, "Unable to retrieve folder {0}",
@@ -782,7 +779,7 @@ namespace MailSim
         /// <param name="operation">name of the operation</param>
         /// <param name="folder">Outlook folder</param>
         /// <param name="register">True to register folder event monitoring, False to unregister folder event monitoring</param>
-        private bool RegisterFolderEvent(string operation, MailFolder folder, bool register)
+        private bool RegisterFolderEvent(string operation, IMailFolder folder, bool register)
         {
             try
             {
@@ -820,9 +817,9 @@ namespace MailSim
             }
 
             // Only processing the MailItem
-            if (Item is MailItem)
+            if (Item is IMailItem)
             {
-                MailItem mail = (MailItem)Item;
+                IMailItem mail = (IMailItem)Item;
                 Log.Out(Log.Severity.Info, eventString, "New item from {0} with subject \"{1}\"!!", mail.SenderName, mail.Subject);
             }
             else
@@ -882,20 +879,20 @@ namespace MailSim
                 {
                     List<string> galUsers;
 
-                    OLAddressList gal = olMailStore.GetGlobalAddressList();
+                    var gal = olMailStore.GetGlobalAddressList();
 
                     // uses the global distribution list if not specified
                     if (string.IsNullOrEmpty(randomRecpt.DistributionList))
                     {
-                        galUsers = gal.GetUsers(null);
+                        galUsers = gal.GetUsers(null).ToList();
                     }
                     // queries the specific distribution list if specified
                     else
                     {
-                        galUsers = gal.GetDLMembers(randomRecpt.DistributionList);
+                        galUsers = gal.GetDLMembers(randomRecpt.DistributionList).ToList();
                     }
 
-                    if (galUsers == null || galUsers.Count == 0)
+                    if (galUsers.Any() == false)
                     {
                         throw new ArgumentException("There is no user in the GAL that matches the recipient criteria");
                     }
@@ -1028,35 +1025,34 @@ namespace MailSim
         /// <param name="folder">folder to retrieve</param>
         /// <param name="subject">case sensitive subject to match</param>
         /// <returns>list of mails if successful, null otherwise</returns>
-        private List<MailItem> GetMails(string operationName, string folder, string subject)
+        private IEnumerable<IMailItem> GetMails(string operationName, string folder, string subject)
         {
-            List<MailItem> mails = new List<MailItem>();
-
             // retrieves the Outlook folder
-            MailFolder mailFolder = olMailStore.GetDefaultFolder(folder);
+            IMailFolder mailFolder = olMailStore.GetDefaultFolder(folder);
             if (mailFolder == null)
             {
                 Log.Out(Log.Severity.Error, operationName, "Unable to retrieve folder {0}",
                     folder);
-                return null;
+                return Enumerable.Empty<IMailItem>();
             }
 
             // retrieves the mail items from the folder
-            MailItems folderItems = mailFolder.GetMailItems();
+            var mails = mailFolder.MailItems;
 
-            if (folderItems == null || folderItems.Count == 0)
+            if (mails.Any() == false)
             {
                 Log.Out(Log.Severity.Error, operationName, "No item in folder {0}", folder);
-                return null;
+                return mails;
             }
 
             // finds all mail items with matching subject if specified
-            mails = FindMailWithSubject(folderItems, subject);
-            if (mails.Count == 0)
+            subject = subject ?? string.Empty;
+            mails = mails.Where(x => x.Subject.Contains(subject));
+
+            if (mails.Any() == false)
             {
                 Log.Out(Log.Severity.Error, operationName, "Unable to find mail with subject {0}",
                     subject);
-                return null;
             }
 
             return mails;
@@ -1070,51 +1066,19 @@ namespace MailSim
         /// <param name="rootFolder">the root folder to retrieve subfolders</param>
         /// <param name="folderName">folder name for searching subfolders</param>
         /// <returns>list of sub folders that matches the folderName</returns>
-        private List<MailFolder> GetMatchingSubFolders(string operationName, MailFolder rootFolder, string folderName)
+        private IEnumerable<IMailFolder> GetMatchingSubFolders(string operationName, IMailFolder rootFolder, string folderName)
         {
-            List<MailFolder> matchingFolders = new List<MailFolder>();
-            MailFolders subFolders = rootFolder.GetSubFolders();
+            var subFolders = rootFolder.SubFolders;
 
-            if (subFolders.Count == 0)
+            if (subFolders.Any() == false)
             {
-                Log.Out(Log.Severity.Warning, operationName, "No subfolder in folder {0}", rootFolder.Name);
+                Log.Out(Log.Severity.Warning, operationName, "No subfolders in folder {0}", rootFolder.Name);
             }
 
-            foreach (MailFolder folder in subFolders)
-            {
-                // we just copy all the folders to the list if folderName is not specified
-                if (string.IsNullOrEmpty(folderName) || folder.Name.Contains(folderName))
-                {
-                    matchingFolders.Add(folder);
-                }
-            }
+            folderName = folderName ?? string.Empty;
 
-            return matchingFolders;
+            return subFolders.Where(x => x.Name.Contains(folderName));
         }
-
-
-        /// <summary>
-        /// This method finds all the mails that match the given subject
-        /// </summary>
-        /// <param name="mails">mails to search for</param>
-        /// <param name="subject">subject to match</param>
-        /// <returns>list of matched mails</returns>
-        private List<MailItem> FindMailWithSubject(MailItems mails, string subject)
-        {
-            List<MailItem> matchingMails = new List<MailItem>();
-
-            // loops thru each mail item to find the matching subject ones
-            foreach (MailItem item in mails)
-            {
-                if (string.IsNullOrEmpty(subject) || item.Subject.Contains(subject))
-                {
-                    matchingMails.Add(item);
-                }
-            }
-
-            return matchingMails;
-        }
-
 
         /// <summary>
         /// This method updates the registry to turn on/off Outlook prompts.

--- a/MailSim/MailSim/MailSim.csproj
+++ b/MailSim/MailSim/MailSim.csproj
@@ -32,7 +32,8 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <PropertyGroup>
-    <ApplicationIcon>MailSim_gray_310h.ico</ApplicationIcon>
+    <ApplicationIcon>
+    </ApplicationIcon>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Microsoft.Office.Interop.Outlook, Version=15.0.0.0, Culture=neutral, PublicKeyToken=71e9bce111e9429c, processorArchitecture=MSIL">
@@ -48,21 +49,23 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="ConfigurationFile.cs" />
+    <Compile Include="Contracts\IAddressBook.cs" />
+    <Compile Include="Contracts\IMailFolder.cs" />
+    <Compile Include="Contracts\IMailItem.cs" />
+    <Compile Include="Contracts\IMailStore.cs" />
     <Compile Include="ExecuteSequence.cs" />
     <Compile Include="Log.cs" />
-    <Compile Include="MailConnection.cs" />
-    <Compile Include="MailFolder.cs" />
-    <Compile Include="MailFolders.cs" />
-    <Compile Include="MailItem.cs" />
-    <Compile Include="MailItems.cs" />
     <Compile Include="MailSimMain.cs" />
     <Compile Include="MailSimTest.cs" />
-    <Compile Include="MailStore.cs" />
-    <Compile Include="OLAddressList.cs" />
     <Compile Include="Operations.cs">
       <DependentUpon>Operations.xsd</DependentUpon>
     </Compile>
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="ProviderFactory.cs" />
+    <Compile Include="ProvidersOM\AddressBookProviderOM.cs" />
+    <Compile Include="ProvidersOM\MailFolderProviderOM.cs" />
+    <Compile Include="ProvidersOM\MailItemProviderOM.cs" />
+    <Compile Include="ProvidersOM\MailStoreProviderOM.cs" />
     <Compile Include="Sequence.cs">
       <DependentUpon>Sequence.xsd</DependentUpon>
     </Compile>

--- a/MailSim/MailSim/ProviderFactory.cs
+++ b/MailSim/MailSim/ProviderFactory.cs
@@ -1,0 +1,19 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+using MailSim.Contracts;
+using MailSim.ProvidersOM;
+
+namespace MailSim
+{
+    class ProviderFactory
+    {
+        public static IMailStore CreateMailStore(string mailboxName)
+        {
+            return new MailStoreProviderOM(mailboxName);
+        }
+    }
+}

--- a/MailSim/MailSim/ProvidersOM/AddressBookProviderOM.cs
+++ b/MailSim/MailSim/ProvidersOM/AddressBookProviderOM.cs
@@ -1,0 +1,71 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+using Outlook = Microsoft.Office.Interop.Outlook;
+using MailSim.Contracts;
+
+namespace MailSim.ProvidersOM
+{
+    class AddressBookProviderOM : IAddressBook
+    {
+       private readonly Outlook.AddressList _addressList;
+
+        /// <summary>
+        /// Constructor
+        /// </summary>
+        /// <param name="addressList"></param>
+        public AddressBookProviderOM(Outlook.AddressList addressList)
+        {
+            _addressList = addressList;
+        }
+
+        /// <summary>
+        /// Builds list of addresses for all users in the Address List that have display name match
+        /// </summary>
+        /// <param name="match"> string to match in user name or null to return all users in the GAL</param>
+        /// <returns>List of SMTP addresses of matching users in the address list. The list will be empty if no users exist or match.</returns>
+        public IEnumerable<string> GetUsers(string match)
+        {
+            foreach (Outlook.AddressEntry addrEntry in _addressList.AddressEntries)
+            {
+                if (addrEntry.AddressEntryUserType == Outlook.OlAddressEntryUserType.olExchangeUserAddressEntry)
+                {
+                    if ((match == null) || addrEntry.Name.Contains(match))
+                    {
+                        yield return addrEntry.GetExchangeUser().PrimarySmtpAddress;
+                    }
+                }
+            }
+        }
+
+        /// <summary>
+        /// Builds list of addresses for all members of Exchange Distribution list in the Address List
+        /// </summary>
+        /// <param name="dLName">Exchane Distribution List Name</param>
+        /// <returns>List of SMTP addresses of DL members or null if DL is not found. Nesting DLs are not expanded. </returns>
+        public IEnumerable<string> GetDLMembers(string dLName)
+        {
+            foreach (Outlook.AddressEntry addrEntry in _addressList.AddressEntries)
+            {
+                if ((addrEntry.AddressEntryUserType == Outlook.OlAddressEntryUserType.olExchangeDistributionListAddressEntry)
+                    && (addrEntry.Name.Equals(dLName, StringComparison.OrdinalIgnoreCase)))
+                {
+                    foreach(Outlook.AddressEntry member in addrEntry.GetExchangeDistributionList().GetExchangeDistributionListMembers())
+                    {
+                        if (member.AddressEntryUserType == Outlook.OlAddressEntryUserType.olExchangeUserAddressEntry)
+                        {
+                            yield return member.GetExchangeUser().PrimarySmtpAddress;
+                        }
+                        else if (addrEntry.AddressEntryUserType == Outlook.OlAddressEntryUserType.olExchangeDistributionListAddressEntry)
+                        {
+                            yield return member.GetExchangeDistributionList().PrimarySmtpAddress;
+                        }
+                    }
+               }
+            }
+        }
+    }
+}

--- a/MailSim/MailSim/ProvidersOM/MailFolderProviderOM.cs
+++ b/MailSim/MailSim/ProvidersOM/MailFolderProviderOM.cs
@@ -1,0 +1,136 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+using Outlook = Microsoft.Office.Interop.Outlook;
+using MailSim.Contracts;
+
+namespace MailSim.ProvidersOM
+{
+    class MailFolderProviderOM : IMailFolder 
+    {
+        private readonly Outlook.Folder _folder;
+        private Action<IMailItem> _itemAddCallback;
+
+        internal MailFolderProviderOM(Outlook.Folder folder)
+        {
+            _folder = folder;
+        }
+
+        public string Name
+        {
+            get
+            {
+                return _folder.Name;
+            }
+        }
+
+        public string FolderPath
+        {
+            get
+            {
+                return _folder.FolderPath;
+            }
+        }
+
+        public IEnumerable<IMailFolder> SubFolders
+        {
+            get
+            {
+                return GetSubFolders();
+            }
+        }
+
+        private IEnumerable<IMailFolder> GetSubFolders()
+        {
+            foreach (var f in _folder.Folders)
+            {
+                yield return new MailFolderProviderOM(f as Outlook.Folder);
+            }
+        }
+
+        public void Delete()
+        {
+            _folder.Delete();
+        }
+
+        public void RegisterItemAddEventHandler(Action<IMailItem> callback)
+        {
+            _itemAddCallback = callback;
+            _folder.Items.ItemAdd += new Outlook.ItemsEvents_ItemAddEventHandler(Items_ItemAddEvent);
+        }
+
+        public void UnRegisterItemAddEventHandler()
+        {
+            if (_itemAddCallback != null)
+            {
+                _folder.Items.ItemAdd -= new Outlook.ItemsEvents_ItemAddEventHandler(Items_ItemAddEvent);
+                _itemAddCallback = null;
+            }
+        }
+
+        /// <summary>
+        /// Adds event to the item
+        /// </summary>
+        /// <param name="Item"></param>
+        private void Items_ItemAddEvent(object Item)
+        {
+            if ((_itemAddCallback != null) && (Item != null) && (Item is Outlook.MailItem))
+            {
+                Outlook.MailItem mail = (Outlook.MailItem)Item;
+                _itemAddCallback(new MailItemProviderOM(mail));
+            }
+        }
+
+        public int MailItemsCount
+        {
+            get
+            {
+                return ((null == _folder.Items) ? 0 : _folder.Items.Count);
+            }
+        }
+        public int SubFoldersCount
+        {
+            get
+            {
+                return ((null == _folder.Folders) ? 0 : _folder.Folders.Count);
+            }
+        }
+
+        public IMailFolder AddSubFolder(string name)
+        {
+            return new MailFolderProviderOM(_folder.Folders.Add(name) as Outlook.Folder);
+        }
+
+        public IEnumerable<IMailItem> MailItems
+        {
+            get
+            {
+                return GetMailItems();
+            }
+        }
+
+        private IEnumerable<IMailItem> GetMailItems()
+        {
+            if (null == _folder.Items)
+            {
+                yield break;
+            }
+
+            foreach (var item in _folder.Items)
+            {
+                yield return new MailItemProviderOM(item as Outlook.MailItem);
+            }
+        }
+
+        internal Outlook.Folder Handle
+        {
+            get
+            {
+                return _folder;
+            }
+        }
+    }
+}

--- a/MailSim/MailSim/ProvidersOM/MailItemProviderOM.cs
+++ b/MailSim/MailSim/ProvidersOM/MailItemProviderOM.cs
@@ -1,0 +1,117 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+using Outlook = Microsoft.Office.Interop.Outlook;
+using MailSim.Contracts;
+
+namespace MailSim.ProvidersOM
+{
+    class MailItemProviderOM : IMailItem
+    {
+        private Outlook._MailItem _mailItem;
+
+        internal MailItemProviderOM(Outlook.MailItem mailItem)
+        {
+            _mailItem = mailItem;
+        }
+
+        public void AddRecipient(string recipient)
+        {
+            _mailItem.Recipients.Add(recipient);
+        }
+
+        public void AddAttachment(string file)
+        {
+            _mailItem.Attachments.Add(file);
+        }
+
+        public void AddAttachment(IMailItem mailItem)
+        {
+            var provider = mailItem as MailItemProviderOM;
+            _mailItem.Attachments.Add(provider.Handle);
+        }
+
+        public void Move(IMailFolder newFolder)
+        {
+            var provider = newFolder as MailFolderProviderOM;
+            _mailItem = _mailItem.Move(provider.Handle);
+        }
+
+        public void Delete()
+        {
+            _mailItem.Delete();
+        }
+
+        public void Send()
+        {
+            _mailItem.Send();
+        }
+
+        public IMailItem Reply(bool replyAll)
+        {
+            if (replyAll)
+            {
+                return new MailItemProviderOM(_mailItem.ReplyAll());
+            }
+            else
+            {
+                return new MailItemProviderOM(_mailItem.Reply());
+            }
+        }
+
+        public IMailItem Forward()
+        {
+            return new MailItemProviderOM(_mailItem.Forward());
+        }
+
+        public string Subject
+        {
+            get
+            {
+                return _mailItem.Subject;
+            }
+
+            set
+            {
+                _mailItem.Subject = value;
+            }
+        }
+
+        public string Body
+        {
+            get
+            {
+                return _mailItem.Body;
+            }
+
+            set
+            {
+                _mailItem.Body = value;
+            }
+        }
+
+        public string SenderName
+        {
+            get
+            {
+                return _mailItem.Sender.Name;
+            }
+        }
+
+        internal Outlook._MailItem Handle
+        {
+            get
+            {
+                return _mailItem;
+            }
+        }
+
+        public bool ValidateRecipients()
+        {
+            return (_mailItem.Recipients.ResolveAll());
+        }
+    }
+}

--- a/MailSim/MailSim/ProvidersOM/MailStoreProviderOM.cs
+++ b/MailSim/MailSim/ProvidersOM/MailStoreProviderOM.cs
@@ -1,0 +1,197 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Runtime.InteropServices;
+
+using Outlook = Microsoft.Office.Interop.Outlook;
+using MailSim.Contracts;
+using System.Diagnostics;
+
+namespace MailSim.ProvidersOM
+{
+    class MailStoreProviderOM : IMailStore
+    {
+        private Outlook.Store _store;
+        private Outlook.Account _userAccount;
+        private Outlook.Application _outlook;
+        private bool _keepOutlookRunning = false;
+        private Lazy<IMailFolder> _rootFolder;
+
+        private Dictionary<string, Outlook.OlDefaultFolders> _folderTypes = new Dictionary<string, Outlook.OlDefaultFolders>
+        {
+            {"olFolderInbox", Outlook.OlDefaultFolders.olFolderInbox},
+            {"olFolderDeletedItems", Outlook.OlDefaultFolders.olFolderDeletedItems},
+            {"olFolderDrafts", Outlook.OlDefaultFolders.olFolderDrafts},
+            {"olFolderJunk", Outlook.OlDefaultFolders.olFolderJunk},
+            {"olFolderOutbox", Outlook.OlDefaultFolders.olFolderOutbox},
+            {"olFolderSentMail", Outlook.OlDefaultFolders.olFolderSentMail},
+        };
+
+        internal MailStoreProviderOM(string mailboxName)
+        {
+            ConnectToOutlook();
+
+            if (mailboxName != null)
+            {
+                mailboxName = mailboxName.ToLower();
+                _store = AllMailStores().FirstOrDefault(x => x.DisplayName.ToLower() == mailboxName);
+
+                if (_store == null)
+                {
+                    throw new ArgumentException(string.Format("Cannot find store (mailbox) {0} in default profile", mailboxName));
+                }
+            }
+            else
+            {
+                _store = _outlook.Session.DefaultStore;
+            }
+
+            _userAccount = FindUserAccount();
+            _rootFolder = new Lazy<IMailFolder>(GetRootFolder);
+        }
+
+        public string DisplayName
+        {
+            get
+            {
+                return _store.DisplayName;
+            }
+        }
+
+        private Outlook.Account FindUserAccount()
+        {
+            Outlook.Accounts accounts = _outlook.Session.Accounts;
+
+            foreach (Outlook.Account account in accounts)
+            {
+                if (account.SmtpAddress == _store.DisplayName)
+                {
+                    return account;
+                }
+            }
+
+            throw new System.Exception(string.Format("No Account with SmtpAddress: {0} exists!", _store.DisplayName));
+        }
+
+        private IEnumerable<Outlook.Store> AllMailStores()
+        {
+            // Get all mailboxes (stores) in the profile. 
+            //Returns only email stores (skips Public Folders, Delegates, Archives, PSTs)
+            foreach (Outlook.Store store in _outlook.Session.Stores)
+            {
+                if ((store.ExchangeStoreType == Outlook.OlExchangeStoreType.olPrimaryExchangeMailbox)
+                    || (store.ExchangeStoreType == Outlook.OlExchangeStoreType.olAdditionalExchangeMailbox)
+                    || (store.ExchangeStoreType == Outlook.OlExchangeStoreType.olNotExchange))
+                {
+                    yield return store;
+                }
+            }
+        }
+
+        public IMailFolder GetDefaultFolder(string folderName)
+        {
+            Outlook.OlDefaultFolders olFolderType;
+
+            if (_folderTypes.TryGetValue(folderName, out olFolderType) == false)
+            {
+                return null;
+            }
+
+            Outlook.Folder folder = _store.GetDefaultFolder(olFolderType) as Outlook.Folder;
+            return new MailFolderProviderOM(folder);
+        }
+
+        public IMailFolder RootFolder
+        {
+            get
+            {
+                return _rootFolder.Value;
+            }
+        }
+
+        private IMailFolder GetRootFolder()
+        {
+            return new MailFolderProviderOM(_store.GetRootFolder() as Outlook.Folder);
+        }
+
+        public IMailItem NewMailItem()
+        {
+            var mailItem = new MailItemProviderOM(_outlook.CreateItem(Outlook.OlItemType.olMailItem) as Outlook.MailItem);
+            mailItem.Handle.SendUsingAccount = _userAccount;
+            return mailItem;
+        }
+
+        private void ConnectToOutlook()
+        {
+            // Checks whether an Outlook process is currently running
+            try
+            {
+                if (Process.GetProcessesByName("OUTLOOK").Count() > 0)
+                {
+                    Log.Out(Log.Severity.Info, "Connection", "Connecting to an existing Outlook instance");
+                    _outlook = Marshal.GetActiveObject("Outlook.Application") as Outlook.Application;
+                    _keepOutlookRunning = true;
+                    return;
+                }
+
+                // Creates a new instance of Outlook and logs on to the specified profile.
+                Log.Out(Log.Severity.Info, "Connection", "Starting a new Outlook session");
+
+                _outlook = new Outlook.Application();
+                Outlook.NameSpace nameSpace = _outlook.GetNamespace("MAPI");
+                Outlook.Folder mailFolder = (Outlook.Folder)nameSpace.GetDefaultFolder(Outlook.OlDefaultFolders.olFolderInbox);
+            }
+            catch (Exception)
+            {
+                Log.Out(Log.Severity.Error, "Connection", "Error encountered when connecting to Outlook ");
+                throw;
+            }
+        }
+
+        /// <summary>
+        /// Finds the Global Address List associated with the MailStore
+        /// </summary>
+        /// <returns>OLAddressList for GAL or null if store has no GAL</returns>
+        public IAddressBook GetGlobalAddressList()
+        {
+            string PR_EMSMDB_SECTION_UID = @"http://schemas.microsoft.com/mapi/proptag/0x3D150102";
+
+            if (_store == null)
+            {
+                throw new ArgumentNullException();
+            }
+
+            Outlook.PropertyAccessor oPAStore = _store.PropertyAccessor;
+            string storeUID = oPAStore.BinaryToString(oPAStore.GetProperty(PR_EMSMDB_SECTION_UID));
+
+            foreach (Outlook.AddressList addrList in _store.Session.AddressLists)
+            {
+                Outlook.PropertyAccessor oPAAddrList = addrList.PropertyAccessor;
+                string addrListUID = oPAAddrList.BinaryToString(oPAAddrList.GetProperty(PR_EMSMDB_SECTION_UID));
+
+                // Returns addrList if match on storeUID
+                // and type is olExchangeGlobalAddressList.
+                if (addrListUID == storeUID && addrList.AddressListType ==
+                    Outlook.OlAddressListType.olExchangeGlobalAddressList)
+                {
+                    return new AddressBookProviderOM(addrList);
+                }
+            }
+
+            return null;
+        }
+
+        ~MailStoreProviderOM()
+        {
+            // Closes the Outlook process
+            if (_outlook != null && !_keepOutlookRunning)
+            {
+                Console.WriteLine("Exiting Outlook");
+ 
+                ((Outlook._Application)_outlook).Quit();
+            }
+        }
+    }
+}


### PR DESCRIPTION
This commit changes Mailsim execution logic to use interfaces instead of concrete classes.

There are two new folders: Contracts and ProvidersOM. Contracts contains interface definitions, ProvidersOM contains implementation of those interfaces for OM/MAPI.

There shouldn't be any functional changes.